### PR TITLE
Use additional `ln` flags to avoid recursive links.

### DIFF
--- a/lnhubgrp
+++ b/lnhubgrp
@@ -21,7 +21,7 @@ echo "Creating links to: "$LNKPATH
 MBRSTR=$(members "$GRP")
 MBRS=($MBRSTR) # array of members
 for i in ${MBRS[@]}; do
-  lncmd="ln -s "$LNKPATH" /home/"$i"/"$1;
+  lncmd="ln -snf "$LNKPATH" /home/"$i"/"$1;
   $lncmd;
   echo "Added link in /home/"$i"."
 done


### PR DESCRIPTION
When re-running the script (e.g. after adding more users to a group), recursive symbolic links are created in the user directories. Consider a group `test`; this would results in a link `~/test/test` for all users. To avoid this, use additional `ln` flags:

-n, --no-dereference
       treat LINK_NAME as a normal file if it is a symbolic link to a directory
-f, --force
       remove existing destination files

See also:
- manpages: https://manpages.org/ln
- discussion: https://unix.stackexchange.com/questions/207294/create-symlink-overwrite-if-one-exists